### PR TITLE
fix(TCDICORE-498): auto-fail stuck datasets and add force-fail button

### DIFF
--- a/forms/src/main/java/org/devgateway/toolkit/forms/service/DatasetClientService.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/service/DatasetClientService.java
@@ -3,6 +3,7 @@ package org.devgateway.toolkit.forms.service;
 import org.apache.commons.io.FileUtils;
 import org.devgateway.toolkit.forms.client.DataSetClientException;
 import org.devgateway.toolkit.forms.client.DatasetClient;
+import org.devgateway.toolkit.forms.client.DatasetJobStatus;
 import org.devgateway.toolkit.persistence.dao.data.CSVDataset;
 import org.devgateway.toolkit.persistence.dao.data.Dataset;
 import org.devgateway.toolkit.persistence.dao.data.TetsimDataset;
@@ -28,6 +29,7 @@ import static org.devgateway.toolkit.persistence.dao.DBConstants.Status.ERROR_IN
 import static org.devgateway.toolkit.persistence.dao.DBConstants.Status.ERROR_IN_UNPUBLISHING;
 import static org.devgateway.toolkit.persistence.dao.DBConstants.Status.PUBLISHED;
 import static org.devgateway.toolkit.persistence.dao.DBConstants.Status.PUBLISHING;
+import static org.devgateway.toolkit.persistence.dao.DBConstants.Status.UNPUBLISHING;
 
 @Service
 public class DatasetClientService {
@@ -55,32 +57,64 @@ public class DatasetClientService {
 
     private void checkDatasetJobs(List<Dataset> datasets) {
         datasets.forEach(d -> {
-            ServiceMetadata serviceMetadata = eurekaClientService.findByName(d.getDestinationService());
-            DatasetClient client = new DatasetClient(serviceMetadata.getUrl());
-            String status = client.getDatasetJobStatus(CODE_PREFIX + d.getId()).getStatus();
-            String initialStatus = d.getStatus();
-            if (COMPLETED.equals(status)) {
-                String completedStatus = getCompletedStatus(initialStatus);
-                d.setStatus(completedStatus);
-                logger.info(String.format("The dataset with id %s changed the status from %s to %s",
-                        d.getId(), initialStatus, completedStatus));
-            } else if (ERROR.equals(status)) {
-                String errorStatus = getErrorStatus(initialStatus);
-                d.setStatus(errorStatus);
-                logger.info(String.format("The dataset with id %s changed the status from %s to %s",
-                        d.getId(), initialStatus, errorStatus));
-            }
+            try {
+                ServiceMetadata serviceMetadata = eurekaClientService.findByName(d.getDestinationService());
+                DatasetClient client = new DatasetClient(serviceMetadata.getUrl());
+                DatasetJobStatus jobStatus = client.getDatasetJobStatus(CODE_PREFIX + d.getId());
+                String initialStatus = d.getStatus();
 
-            if (!initialStatus.equals(d.getStatus())) {
-                if (d instanceof TetsimDataset) {
-                    tetsimDatasetService.save((TetsimDataset) d);
-                } else if (d instanceof CSVDataset) {
-                    csvDatasetService.save((CSVDataset) d);
+                if (jobStatus == null) {
+                    // Remote service returned a non-2xx response (job not found or server error) — auto-fail
+                    String errorStatus = getErrorStatus(initialStatus);
+                    d.setStatus(errorStatus);
+                    logger.warn("Dataset {} job not found on remote service, auto-failing from {} to {}",
+                            d.getId(), initialStatus, errorStatus);
                 } else {
-                    throw new RuntimeException("Invalid dataset class");
+                    String status = jobStatus.getStatus();
+                    if (COMPLETED.equals(status)) {
+                        String completedStatus = getCompletedStatus(initialStatus);
+                        d.setStatus(completedStatus);
+                        logger.info("The dataset with id {} changed the status from {} to {}",
+                                d.getId(), initialStatus, completedStatus);
+                    } else if (ERROR.equals(status)) {
+                        String errorStatus = getErrorStatus(initialStatus);
+                        d.setStatus(errorStatus);
+                        logger.info("The dataset with id {} changed the status from {} to {}",
+                                d.getId(), initialStatus, errorStatus);
+                    }
                 }
+
+                if (!initialStatus.equals(d.getStatus())) {
+                    if (d instanceof TetsimDataset) {
+                        tetsimDatasetService.save((TetsimDataset) d);
+                    } else if (d instanceof CSVDataset) {
+                        csvDatasetService.save((CSVDataset) d);
+                    } else {
+                        throw new RuntimeException("Invalid dataset class");
+                    }
+                }
+            } catch (Exception e) {
+                logger.error("Failed to check job status for dataset {}: {}", d.getId(), e.getMessage(), e);
             }
         });
+    }
+
+    public void forceFailPublishing(Dataset dataset) {
+        String status = dataset.getStatus();
+        if (!PUBLISHING.equals(status) && !UNPUBLISHING.equals(status)) {
+            throw new IllegalStateException("Dataset " + dataset.getId()
+                    + " is not in PUBLISHING or UNPUBLISHING state: " + status);
+        }
+        String errorStatus = getErrorStatus(status);
+        dataset.setStatus(errorStatus);
+        logger.info("Force failing dataset {} from status {} to {}", dataset.getId(), status, errorStatus);
+        if (dataset instanceof TetsimDataset) {
+            tetsimDatasetService.save((TetsimDataset) dataset);
+        } else if (dataset instanceof CSVDataset) {
+            csvDatasetService.save((CSVDataset) dataset);
+        } else {
+            throw new RuntimeException("Invalid dataset class");
+        }
     }
 
     private String getCompletedStatus(final String status) {

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/AbstractEditStatusEntityPage.html
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/AbstractEditStatusEntityPage.html
@@ -87,11 +87,13 @@
         <button wicket:id="submitAndNext" type="button" class="btn btn-info btn-form-action">Save & Next</button>
         <button wicket:id="saveApprove" type="button" class="btn btn-success btn-form-action">Save & Approve</button>
         <button wicket:id="approve" type="button" class="btn btn-success btn-form-action">Approve</button>
-        <button wicket:id="revertToDraft" type="button" class="btn btn-warning btn-form-action">Save & Validate</button>
+        <button wicket:id="revertToDraft" type="button" class="btn btn-warning btn-form-action">Unpublish</button>
+        <button wicket:id="forceFail" type="button" class="btn btn-danger btn-form-action">Force Fail</button>
     </wicket:fragment>
 
     <div wicket:id="approveModal"></div>
     <div wicket:id="unpublishModal"></div>
+    <div wicket:id="forceFailModal"></div>
 
     <wicket:fragment wicket:id="noButtons"></wicket:fragment>
 </wicket:extend>

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/AbstractEditStatusEntityPage.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/AbstractEditStatusEntityPage.java
@@ -93,9 +93,13 @@ public abstract class AbstractEditStatusEntityPage<T extends AbstractStatusAudit
 
     protected SaveEditPageButton revertToDraftPageButton;
 
+    protected SaveEditPageButton forceFailButton;
+
     protected TextContentModal approveModal;
 
     protected TextContentModal unpublishModal;
+
+    protected TextContentModal forceFailModal;
 
     private CheckBoxYesNoToggleBootstrapFormComponent visibleStatusComments;
 
@@ -316,8 +320,14 @@ public abstract class AbstractEditStatusEntityPage<T extends AbstractStatusAudit
         revertToDraftPageButton = getRevertToDraftPageButton();
         entityButtonsFragment.add(revertToDraftPageButton);
 
+        forceFailButton = getForceFailPageButton();
+        entityButtonsFragment.add(forceFailButton);
+
         unpublishModal = createUnpublishModal();
         editForm.add(unpublishModal);
+
+        forceFailModal = createForceFailModal();
+        editForm.add(forceFailModal);
 
         applyDraftSaveBehavior(saveButton);
         applyDraftSaveBehavior(saveDraftContinueButton);
@@ -766,11 +776,60 @@ public abstract class AbstractEditStatusEntityPage<T extends AbstractStatusAudit
         return saveEditPageButton;
     }
 
+    protected SaveEditPageButton getForceFailPageButton() {
+        final SaveEditPageButton button = new SaveEditPageButton("forceFail",
+                new StringResourceModel("forceFailButton", this, null)) {
+
+            @Override
+            protected void onSubmit(final AjaxRequestTarget target) {
+                forceFailModal.show(true);
+                target.add(forceFailModal);
+            }
+
+            @Override
+            protected void onError(final AjaxRequestTarget target) {
+                super.onError(target);
+                target.add(feedbackPanel);
+            }
+        };
+        button.setType(Buttons.Type.Danger);
+        button.setIconType(FontAwesome5IconType.exclamation_triangle_s);
+        return button;
+    }
+
+    protected TextContentModal createForceFailModal() {
+        final TextContentModal modal = new TextContentModal("forceFailModal",
+                new StringResourceModel("forceFailModal", this, null));
+
+        final SaveEditPageButton confirmButton = new SaveEditPageButton("button", Model.of("Yes")) {
+            @Override
+            protected String getOnClickScript() {
+                return WebConstants.DISABLE_FORM_LEAVING_JS;
+            }
+
+            @Override
+            protected void onSubmit(final AjaxRequestTarget target) {
+                onForceFailPublishing(target);
+                super.onSubmit(target);
+            }
+        };
+        confirmButton.setType(Buttons.Type.Danger);
+        confirmButton.setIconType(FontAwesome5IconType.exclamation_triangle_s);
+        modal.addButton(confirmButton);
+        modal.addCloseButton(Model.of("No"));
+
+        return modal;
+    }
+
     protected void onAfterRevertToDraft(AjaxRequestTarget target) {
 
     }
 
     protected void onApprove(AjaxRequestTarget target) {
+
+    }
+
+    protected void onForceFailPublishing(AjaxRequestTarget target) {
 
     }
 
@@ -798,6 +857,7 @@ public abstract class AbstractEditStatusEntityPage<T extends AbstractStatusAudit
         addSaveApproveButtonPermissions(saveApproveButton);
         addApproveButtonPermissions(approveButton);
         addSaveRevertButtonPermissions(revertToDraftPageButton);
+        addForceFailButtonPermissions(forceFailButton);
         addDeleteButtonPermissions(deleteButton);
 
         // no need to display the buttons on print view so we overwrite the above permissions
@@ -822,6 +882,12 @@ public abstract class AbstractEditStatusEntityPage<T extends AbstractStatusAudit
         button.setVisibilityAllowed(button.isVisibilityAllowed()
                 && (PUBLISHED.equals(editForm.getModelObject().getStatus())
                     || ERROR_IN_UNPUBLISHING.equals(editForm.getModelObject().getStatus())));
+    }
+
+    protected void addForceFailButtonPermissions(final Component button) {
+        MetaDataRoleAuthorizationStrategy.authorize(button, Component.RENDER, SecurityConstants.Roles.ROLE_ADMIN);
+        button.setVisibilityAllowed(PUBLISHING.equals(editForm.getModelObject().getStatus())
+                || UNPUBLISHING.equals(editForm.getModelObject().getStatus()));
     }
 
     protected void addSaveApproveButtonPermissions(final Component button) {

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/AbstractEditStatusEntityPage.properties
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/AbstractEditStatusEntityPage.properties
@@ -20,3 +20,5 @@ autosave_message=Form is saving
 autoSaveLabelMessage=Form auto-saved less than {0,number} minutes ago.
 checkedOutToMessage=Checked out to user {0}.
 errorInPublishingTitle=There was an error during {0}. Please check the data and try to republish it. If it doesn't work please contact the admin.
+forceFailButton=Force Fail
+forceFailModal=Are you sure you want to force fail this publishing process? The dataset status will be set to error and it will need to be re-published.

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/dataset/EditCSVDatasetPage.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/dataset/EditCSVDatasetPage.java
@@ -226,6 +226,17 @@ public class EditCSVDatasetPage extends AbstractEditStatusEntityPage<CSVDataset>
         setResponsePage(listPageClass);
     }
 
+    @Override
+    protected void onForceFailPublishing(final AjaxRequestTarget target) {
+        try {
+            datasetClientService.forceFailPublishing(editForm.getModelObject());
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            failedModal.show(target);
+        }
+        setResponsePage(listPageClass, getSaveEditParameters());
+    }
+
     protected BootstrapCancelButton getCancelButton(final String id) {
         return new CancelEditPageButton(id, new StringResourceModel("cancelButton", this, null));
     }

--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/dataset/EditTetsimDatasetPage.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/page/edit/dataset/EditTetsimDatasetPage.java
@@ -164,6 +164,17 @@ public class EditTetsimDatasetPage extends AbstractEditStatusEntityPage<TetsimDa
         setResponsePage(listPageClass);
     }
 
+    @Override
+    protected void onForceFailPublishing(final AjaxRequestTarget target) {
+        try {
+            datasetClientService.forceFailPublishing(editForm.getModelObject());
+        } catch (Exception e) {
+            logger.error(e.getMessage(), e);
+            failedModal.show(target);
+        }
+        setResponsePage(listPageClass);
+    }
+
     protected BootstrapCancelButton getCancelButton(final String id) {
         return new CancelEditPageButton(id, new StringResourceModel("cancelButton", this, null));
     }


### PR DESCRIPTION
Datasets stuck in PUBLISHING/UNPUBLISHING state could never recover if the remote service lost track of the job. Two fixes:

1. Auto-fail via scheduler: DatasetClientService.checkDatasetJobs now null-checks the job status response. A null (non-2xx from remote) is treated as job-not-found and immediately transitions the dataset to ERROR_IN_PUBLISHING or ERROR_IN_UNPUBLISHING instead of leaving it stuck forever. Each dataset iteration is also independently try-caught so one failure doesn't abort the rest.

2. Manual force-fail button: Admin-only "Force Fail" button added to AbstractEditStatusEntityPage, visible only when status is PUBLISHING or UNPUBLISHING. Calls DatasetClientService.forceFailPublishing() which validates state before transitioning to the appropriate error status. Both EditCSVDatasetPage and EditTetsimDatasetPage implement the onForceFailPublishing hook.