### PR TITLE
TCDICORE-498: fix NPE on file upload when internalUploadModel is null after page deserialization

### DIFF
--- a/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/FileInputBootstrapFormComponentWrapper.java
+++ b/forms/src/main/java/org/devgateway/toolkit/forms/wicket/components/form/FileInputBootstrapFormComponentWrapper.java
@@ -535,6 +535,15 @@ public class FileInputBootstrapFormComponentWrapper<
             protected void onSubmit(final AjaxRequestTarget target) {
                 super.onSubmit(target);
 
+                // internalUploadModel is transient; after page deserialization it will
+                // be null. Re-sync it from this component's own (non-transient) model
+                // slot, where the same ListModel instance is still stored.
+                if (internalUploadModel == null) {
+                    internalUploadModel = (IModel<
+                        List<FileUpload>
+                    >) getDefaultModel();
+                }
+
                 List<FileUpload> fileUploads = internalUploadModel.getObject();
                 try {
                     // Clear any feedback messages accumulated from previous failed submissions


### PR DESCRIPTION
## Problem
`internalUploadModel` is declared `transient` in `FileInputBootstrapFormComponentWrapper` to avoid serialising large file-upload byte arrays into Wicket's page store. When an AJAX file-upload request arrives, Wicket deserialises the page — and the `transient` field comes back as `null`. The anonymous `BootstrapFileInput.onSubmit()` then tries to call `.getObject()` on it, causing:

```
java.lang.NullPointerException: Cannot invoke "org.apache.wicket.model.IModel.getObject()"
because "this.this$0.internalUploadModel" is null
```

## Fix
Re-sync the transient field from the component's own (non-transient) default model slot at the top of `onSubmit()`. The same `ListModel` instance is passed to the `BootstrapFileInput` constructor and survives serialisation inside that component — so `getDefaultModel()` always returns it intact.

## Ticket
TCDICORE-498